### PR TITLE
fix: added API comment size setting that forgot

### DIFF
--- a/src/js/api.js
+++ b/src/js/api.js
@@ -36,6 +36,7 @@ export default {
                                 color: item[2],
                                 author: item[3],
                                 text: item[4],
+                                size: (item[5] ? (((item[5] === 'big') || (item[5] === 'small')) ? item[5] : 'medium') : 'medium'),
                             }))
                         );
                 } else {
@@ -46,6 +47,7 @@ export default {
                             color: '#ffeaea',
                             author: '',
                             text: '',
+                            size: 'medium',
                         });
                 }
             })


### PR DESCRIPTION
## 概要
- api.jsからdanmakuのsize設定が抜けているのを修正

## 詳細
1.27.1のリリースにて https://github.com/tsukumijima/DPlayer/commit/4421080814564485d428c2cc0f7b69eb44473cc8 と https://github.com/tsukumijima/DPlayer/commit/c63f50f5a4a3c1664ed43e6a5d9b0618da9f1bbc でdanmakuに`size`設定を行えるようになりましたが、
デフォルトのapi(`danmaku: {api: 'URL'}`)でjsonファイルを与えても`size`設定ができない状態になっていました。
api.jsに新たにsize設定を追加することで、下記形式のjsonでdanmakuの大きさを設定することができるように修正いたします。
```
{
  "code":0,
  "data":[
    [1,"","","","big_comment","big"],
    [1,"","","","medium_comment","medium"],
    [1,"","","","small_comment","small"]
  ]
}
※data形式['time', 'type', 'color', 'author', 'text', 'size']
```
なお、`size`追加前とのjson形式の互換性を保つためにdata配列の末尾に`size`を置き、
与えられたjsonに項目が存在しなければデフォルト値の`medium`を格納します。
加えて`item[5]`が存在した場合でも、`size`の値以外を入れられている可能性もありますので、
その場合にも`medium`になるようにしています。

修正内容に問題があるようであれば、ご指摘ください。