### PR TITLE
fix danmaku

### DIFF
--- a/src/template/player.art
+++ b/src/template/player.art
@@ -14,9 +14,7 @@
     <div class="dplayer-subtitle"></div>
     <div class="dplayer-bezel">
         <span class="dplayer-bezel-icon"></span>
-        {{ if options.danmaku }}
-        <span class="dplayer-danloading">{{ tran('Danmaku is loading') }}</span>
-        {{ /if }}
+        <span class="dplayer-danloading" style="display: none">{{ tran('Danmaku is loading') }}</span>
         <span class="dplayer-loading-icon">{{@ icons.loading }}</span>
     </div>
 </div>

--- a/src/ts/danmaku.ts
+++ b/src/ts/danmaku.ts
@@ -72,16 +72,21 @@ class Danmaku {
 
     load(): void {
         let apiurl;
-        if (this.options.api.maximum) {
-            apiurl = `${this.options.api.address}?id=${this.options.api.id}&max=${this.options.api.maximum}`;
-        } else {
-            apiurl = `${this.options.api.address}?id=${this.options.api.id}`;
+        if (this.options.api.address) {
+            const apiParamsObj = Object.assign({},
+                this.options.api.id ? { id: this.options.api.id } : {},
+                this.options.api.maximum ? { max: this.options.api.maximum } : {}
+            );
+            const apiParamsStr = Object.entries(apiParamsObj)
+                .map(([key, value]) => `${key}=${value}`)
+                .join('&');
+            apiurl = apiParamsStr ? `${this.options.api.address}?${apiParamsStr}` : this.options.api.address;
         }
         const endpoints = (this.options.api.addition || []).slice(0);
-        endpoints.push(apiurl);
+        if (apiurl) endpoints.push(apiurl);
         this.events && this.events.trigger('danmaku_load_start', endpoints);
 
-        this._readAllEndpoints(endpoints, (results) => {
+        endpoints.length > 0 && this._readAllEndpoints(endpoints, (results) => {
             this.dan = ([] as DPlayerType.Dan[]).concat(...results).sort((a, b) => a.time - b.time);
             window.requestAnimationFrame(() => {
                 this.frame();

--- a/src/ts/danmaku.ts
+++ b/src/ts/danmaku.ts
@@ -1,6 +1,7 @@
 import DPlayer from './player';
 import Events from './events';
 import utils from './utils';
+import defaultApiBackend from './api';
 import * as DPlayerType from './types';
 
 interface DanmakuOptions {
@@ -84,7 +85,7 @@ class Danmaku {
         }
         const endpoints = (this.options.api.addition || []).slice(0);
         if (apiurl) endpoints.push(apiurl);
-        if (this.options.apiBackend) endpoints.push('apiBackend');
+        if (this.options.apiBackend !== defaultApiBackend) endpoints.push('apiBackend');
         this.events && this.events.trigger('danmaku_load_start', endpoints);
 
         this._readAllEndpoints(endpoints, (results) => {

--- a/src/ts/danmaku.ts
+++ b/src/ts/danmaku.ts
@@ -84,9 +84,10 @@ class Danmaku {
         }
         const endpoints = (this.options.api.addition || []).slice(0);
         if (apiurl) endpoints.push(apiurl);
+        if (this.options.apiBackend) endpoints.push('apiBackend');
         this.events && this.events.trigger('danmaku_load_start', endpoints);
 
-        endpoints.length > 0 && this._readAllEndpoints(endpoints, (results) => {
+        this._readAllEndpoints(endpoints, (results) => {
             this.dan = ([] as DPlayerType.Dan[]).concat(...results).sort((a, b) => a.time - b.time);
             window.requestAnimationFrame(() => {
                 this.frame();

--- a/src/ts/danmaku.ts
+++ b/src/ts/danmaku.ts
@@ -75,7 +75,7 @@ class Danmaku {
         if (this.options.api.address) {
             const apiParamsObj = Object.assign({},
                 this.options.api.id ? { id: this.options.api.id } : {},
-                this.options.api.maximum ? { max: this.options.api.maximum } : {}
+                this.options.api.maximum ? { max: this.options.api.maximum } : {},
             );
             const apiParamsStr = Object.entries(apiParamsObj)
                 .map(([key, value]) => `${key}=${value}`)
@@ -110,6 +110,7 @@ class Danmaku {
      */
     _readAllEndpoints(endpoints: string[], callback: (results: DPlayerType.Dan[][]) => void): void {
         const results: DPlayerType.Dan[][] = [];
+        let errorCount = 0;
         let readCount = 0;
 
         for (let i = 0; i < endpoints.length; ++i) {
@@ -124,11 +125,17 @@ class Danmaku {
                     }
                 },
                 error: (message) => {
-                    this.options.error(message || this.options.tran('Danmaku load failed'));
+                    if (message) this.options.error(message);
                     results[i] = [];
 
+                    ++errorCount;
                     ++readCount;
                     if (readCount === endpoints.length) {
+                        if (errorCount !== endpoints.length) {
+                            this.options.error(this.options.tran('Danmaku load partial failed'));
+                        } else {
+                            this.options.error(this.options.tran('Danmaku load failed'));
+                        }
                         callback(results);
                     }
                 },

--- a/src/ts/player.ts
+++ b/src/ts/player.ts
@@ -364,7 +364,12 @@ class DPlayer {
      * @param {Object | boolean} danmaku - new danmaku info
      * @param {Boolean} remember - whether to remember the current video time and speed
      */
-    switchVideo(video: { url: string; type?: DPlayerType.VideoType | string; pic?: string; }, danmakuAPI?: DPlayerType.Danmaku | boolean, remember = false): void {
+    switchVideo(
+        video: { url: string; type?: DPlayerType.VideoType | string; pic?: string; },
+        danmakuAPI?: DPlayerType.Danmaku | boolean,
+        remember = false,
+        apiBackend: DPlayerType.APIBackend = defaultApiBackend,
+    ): void {
         this.pause();
         const seek = this.video.currentTime;
         const speed = this.video.playbackRate;
@@ -377,8 +382,8 @@ class DPlayer {
                 if (!remember) this.bar.set('loaded', 0, 'width');
                 if (!remember) this.template.ptime.textContent = '00:00';
                 this.template.danmaku.innerHTML = '';
+                this.danmaku.options.apiBackend = apiBackend;
                 if (typeof danmakuAPI === 'object') {
-                    this.danmaku.options.apiBackend = defaultApiBackend;
                     this.danmaku.reload({
                         id: danmakuAPI.id,
                         address: danmakuAPI.api,
@@ -387,9 +392,11 @@ class DPlayer {
                         addition: danmakuAPI.addition,
                         user: danmakuAPI.user,
                     });
+                } else {
+                    this.danmaku.reload({});
                 }
             } else {
-                this.initDanmaku(danmakuAPI as DPlayerType.Danmaku);
+                this.initDanmaku(danmakuAPI as DPlayerType.Danmaku, apiBackend);
             }
         }
 

--- a/src/ts/player.ts
+++ b/src/ts/player.ts
@@ -364,7 +364,7 @@ class DPlayer {
      * @param {Object | boolean} danmaku - new danmaku info
      * @param {Boolean} remember - whether to remember the current video time and speed
      */
-    switchVideo(video: { url: string; type?: DPlayerType.VideoType | string; pic?: string; }, danmakuAPI?: DPlayerType.Danmaku | boolean, remember: boolean = false): void {
+    switchVideo(video: { url: string; type?: DPlayerType.VideoType | string; pic?: string; }, danmakuAPI?: DPlayerType.Danmaku | boolean, remember = false): void {
         this.pause();
         const seek = this.video.currentTime;
         const speed = this.video.playbackRate;
@@ -378,6 +378,7 @@ class DPlayer {
                 if (!remember) this.template.ptime.textContent = '00:00';
                 this.template.danmaku.innerHTML = '';
                 if (typeof danmakuAPI === 'object') {
+                    this.danmaku.options.apiBackend = defaultApiBackend;
                     this.danmaku.reload({
                         id: danmakuAPI.id,
                         address: danmakuAPI.api,

--- a/src/ts/player.ts
+++ b/src/ts/player.ts
@@ -20,6 +20,7 @@ import HotKey from './hotkey';
 import ContextMenu from './contextmenu';
 import InfoPanel from './info-panel';
 import tplVideo from '../template/video.art';
+import defaultApiBackend from './api';
 import * as DPlayerType from './types';
 
 let index = 0;
@@ -83,9 +84,6 @@ class DPlayer {
         this.container = this.options.container;
 
         this.container.classList.add('dplayer');
-        if (!this.options.danmaku) {
-            this.container.classList.add('dplayer-no-danmaku');
-        }
         if (this.options.live) {
             this.container.classList.add('dplayer-live');
         } else {
@@ -132,44 +130,7 @@ class DPlayer {
 
         this.controller = new Controller(this);
 
-        if (this.options.danmaku) {
-            this.danmaku = new Danmaku({
-                player: this,
-                container: this.template.danmaku,
-                opacity: this.user.get('opacity'),
-                callback: () => {
-                    setTimeout(() => {
-                        this.template.danmakuLoading.style.display = 'none';
-
-                        // autoplay
-                        if (this.options.autoplay) {
-                            this.play();
-                        }
-                    }, 0);
-                },
-                error: (msg: string) => {
-                    this.notice(msg, undefined, undefined, '#FF6F6A');
-                },
-                apiBackend: this.options.apiBackend,
-                borderColor: this.options.theme,
-                fontSize: this.options.danmaku.fontSize,
-                time: () => this.video.currentTime,
-                unlimited: this.user.get('unlimited'),
-                speedRate: this.options.danmaku.speedRate,
-                api: {
-                    id: this.options.danmaku.id,
-                    address: this.options.danmaku.api,
-                    token: this.options.danmaku.token,
-                    maximum: this.options.danmaku.maximum,
-                    addition: this.options.danmaku.addition,
-                    user: this.options.danmaku.user,
-                },
-                events: this.events,
-                tran: (msg: string) => this.tran(msg),
-            });
-
-            this.comment = new Comment(this);
-        }
+        this.initDanmaku(this.options.danmaku, this.options.apiBackend);
 
         this.plugins = {};
         this.docClickFun = () => {
@@ -400,30 +361,87 @@ class DPlayer {
      * Switch to a new video
      *
      * @param {Object} video - new video info
-     * @param {Object} danmaku - new danmaku info
+     * @param {Object | boolean} danmaku - new danmaku info
+     * @param {Boolean} remember - whether to remember the current video time and speed
      */
-    switchVideo(video: { url: string; type?: DPlayerType.VideoType | string; pic?: string; }, danmakuAPI?: DPlayerType.Danmaku): void {
+    switchVideo(video: { url: string; type?: DPlayerType.VideoType | string; pic?: string; }, danmakuAPI?: DPlayerType.Danmaku | boolean, remember: boolean = false): void {
         this.pause();
+        const seek = this.video.currentTime;
+        const speed = this.video.playbackRate;
         this.video.poster = video.pic ? video.pic : '';
         this.video.src = video.url;
         this.initMSE(this.video, video.type || 'auto');
         if (danmakuAPI) {
-            this.template.danmakuLoading.style.display = 'block';
-            this.bar.set('played', 0, 'width');
-            this.bar.set('loaded', 0, 'width');
-            this.template.ptime.textContent = '00:00';
-            this.template.danmaku.innerHTML = '';
             if (this.danmaku) {
-                this.danmaku.reload({
-                    id: danmakuAPI.id,
-                    address: danmakuAPI.api,
-                    token: danmakuAPI.token,
-                    maximum: danmakuAPI.maximum,
-                    addition: danmakuAPI.addition,
-                    user: danmakuAPI.user,
-                });
+                if (!remember) this.bar.set('played', 0, 'width');
+                if (!remember) this.bar.set('loaded', 0, 'width');
+                if (!remember) this.template.ptime.textContent = '00:00';
+                this.template.danmaku.innerHTML = '';
+                if (typeof danmakuAPI === 'object') {
+                    this.danmaku.reload({
+                        id: danmakuAPI.id,
+                        address: danmakuAPI.api,
+                        token: danmakuAPI.token,
+                        maximum: danmakuAPI.maximum,
+                        addition: danmakuAPI.addition,
+                        user: danmakuAPI.user,
+                    });
+                }
+            } else {
+                this.initDanmaku(danmakuAPI as DPlayerType.Danmaku);
             }
         }
+
+        if (remember) {
+            if (seek !== 0) this.seek(seek);
+            if (speed !== 1.0) this.speed(speed);
+        }
+    }
+
+    initDanmaku(danmakuAPI?: DPlayerType.Danmaku | boolean, apiBackend: DPlayerType.APIBackend = defaultApiBackend): void {
+        if (!danmakuAPI) {
+            this.container.classList.add('dplayer-no-danmaku');
+            return;
+        }
+        this.container.classList.remove('dplayer-no-danmaku');
+
+        this.template.danmakuLoading.style.display = 'block';
+        this.danmaku = new Danmaku({
+            player: this,
+            container: this.template.danmaku,
+            opacity: this.user.get('opacity'),
+            callback: () => {
+                setTimeout(() => {
+                    this.template.danmakuLoading.style.display = 'none';
+
+                    // autoplay
+                    if (this.options.autoplay) {
+                        this.play();
+                    }
+                }, 0);
+            },
+            error: (msg: string) => {
+                this.notice(msg, undefined, undefined, '#FF6F6A');
+            },
+            apiBackend: apiBackend,
+            borderColor: this.options.theme,
+            fontSize: typeof danmakuAPI === 'boolean' ? 24 : danmakuAPI.fontSize || 24,
+            time: () => this.video.currentTime,
+            unlimited: this.user.get('unlimited'),
+            speedRate: typeof danmakuAPI === 'boolean' ? 1 : danmakuAPI.speedRate || 1,
+            api: typeof danmakuAPI === 'boolean' ? {} : {
+                id: danmakuAPI.id,
+                address: danmakuAPI.api,
+                token: danmakuAPI.token,
+                maximum: danmakuAPI.maximum,
+                addition: danmakuAPI.addition,
+                user: danmakuAPI.user,
+            },
+            events: this.events,
+            tran: (msg: string) => this.tran(msg),
+        });
+
+        this.comment = new Comment(this);
     }
 
     initMSE(video: HTMLVideoElement, type: DPlayerType.VideoType | string): void {


### PR DESCRIPTION
1. `apiBackend` ts type cloud have boolean, because used in your demo.
    <img width="556" alt="image" src="https://github.com/user-attachments/assets/48759ba0-969a-4e19-9c4a-7c679416e4ef" />
3. support switchVideo danmaku none to init
4. support switchVideo params remember to old video seek and speed 
    <img width="716" alt="image" src="https://github.com/user-attachments/assets/3e5c22b8-699b-4eaf-99a5-24e9057035f3" />
6. fix (not have id or address params) or (only `danmaku` is true not apiBackend) have request url is undefined
    <img width="444" alt="image" src="https://github.com/user-attachments/assets/25c7f4ad-4df5-43de-9118-624ec3c988ae" />
7. change `api` and `addition` one error use `Danmaku load partial failed`
    <img width="604" alt="image" src="https://github.com/user-attachments/assets/75a680ce-0534-4683-8000-647eef459ee6" />
