### PR TITLE
fix muted not switch icon

### DIFF
--- a/src/ts/player.ts
+++ b/src/ts/player.ts
@@ -375,7 +375,7 @@ class DPlayer {
      * Set volume muted
      */
     muted(muted?: boolean): boolean {
-        if (muted && typeof muted === 'boolean') {
+        if (typeof muted === 'boolean') {
             if (muted) {
                 this.video.muted = true;
                 this.template.volumeIcon.innerHTML = Icons.volumeOff;


### PR DESCRIPTION
`player.video.muted` native method, so it will not switch the interface progress when the volume is restored, and it will not set the icon when muted.
![image](https://github.com/user-attachments/assets/627810f7-5e10-48ed-bff4-6cc3b4f267c8)

provide `muted` method implementation
![image](https://github.com/user-attachments/assets/40f4b7b3-792c-410f-b22d-a34f6373c786)
![image](https://github.com/user-attachments/assets/0ab4b165-b333-408e-a0d4-5f26d59e7a92)
