### PR TITLE
fix: trigger playbackrate to 1 when destroy

### DIFF
--- a/src/ts/player.ts
+++ b/src/ts/player.ts
@@ -1084,7 +1084,7 @@ class DPlayer {
         this.timer.destroy();
         this.setting.destroy();
         this.resizeObserver.disconnect();
-        this.video.src = '';
+        this.video.removeAttribute('src');
         if (!keepContainerInnerHTML) {
             this.container.innerHTML = '';
         }


### PR DESCRIPTION
Setting it to null triggers the loading of a new video, which initializes the `playbackrate` parameter causing it to return 1, and I get an wrong data when I need to memorize it.

`this.video.src = ''`
![712e95a32e95404c2405a13bfc34cc66](https://github.com/user-attachments/assets/6af0dadb-a289-46f3-9635-22666697fc50)

`this.video.removeAttribute('src')`
![06c367ef-d504-40c5-8a19-e33c172a1754](https://github.com/user-attachments/assets/90fbadc6-70db-41dd-8ff2-3de0c09b8033)
