### PR TITLE
fix: improved robustness of HLS audio switching

### DIFF
--- a/src/ts/player.ts
+++ b/src/ts/player.ts
@@ -489,9 +489,11 @@ class DPlayer {
 
                             // Listen for audio tracks updates
                             hls.on(window.Hls.Events.AUDIO_TRACKS_UPDATED, () => {
-                                if (hls.audioTracks.length > 1) {
+                                if (hls.audioTracks.length >= 2) {
                                     // Remove no-audio-switching class if multiple audio tracks are available
                                     this.container.classList.remove('dplayer-no-audio-switching');
+                                } else {
+                                    this.container.classList.add('dplayer-no-audio-switching');
                                 }
                             });
 
@@ -974,7 +976,7 @@ class DPlayer {
                     // switch secondary audio for HLS
                     } else if (window.Hls && this.plugins.hls && this.plugins.hls instanceof window.Hls) {
                         const hls = this.plugins.hls;
-                        if (hls.audioTracks.length > 1) {
+                        if (hls.audioTracks.length >= 2) {
                             hls.audioTrack = 1;  // Switch to secondary audio track
                         }
                     }
@@ -982,7 +984,7 @@ class DPlayer {
                     // switch primary audio for HLS
                     if (window.Hls && this.plugins.hls && this.plugins.hls instanceof window.Hls) {
                         const hls = this.plugins.hls;
-                        if (hls.audioTracks.length > 1) {
+                        if (hls.audioTracks.length >= 2) {
                             hls.audioTrack = 0;  // Switch to primary audio track
                         }
                     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 不具合修正
  * 音声トラック数の判定を見直し、2本以上のトラックがある場合のみ音声切替UIを表示するよう修正。1本以下では非表示となり、誤表示を解消。
  * HLSの音声トラック更新時や主従音声の切替処理でも挙動を統一し、常に正確に表示・非表示が切り替わるよう改善。
  * これにより、複数音声対応コンテンツでの音声切替の信頼性が向上。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->